### PR TITLE
Add worc0260 collator to calamari experimental community collators

### DIFF
--- a/config/prometheus.yml
+++ b/config/prometheus.yml
@@ -479,3 +479,7 @@ scrape_configs:
           # discord, username: pmensik#3434, account id: 482230698367909891
           - calamari.metrics.polkadotters.com
           - kusama.metrics.polkadotters.com
+
+          # discord, username: 'worc0260#7958', account id: 950367739405545532
+          - calamari.metrics.cj.kmapro.de
+          - kusama.metrics.cj.kmapro.de


### PR DESCRIPTION
@grenade I think this is only going to work if all experimental collators are using https, as I've changed it globally. I don't think all the collators are open to the internet, so I couldn't check each of them to see if they were using http/https. So this may need some adjustment before it lands!